### PR TITLE
Opportunity to enable http protocol for testing purposes

### DIFF
--- a/Sources/Base/OAuth2.swift
+++ b/Sources/Base/OAuth2.swift
@@ -316,9 +316,12 @@ public class OAuth2: OAuth2Base {
 		// compose URL base
 		let base = asTokenURL ? (clientConfig.tokenURL ?? clientConfig.authorizeURL) : clientConfig.authorizeURL
 		let comp = NSURLComponents(URL: base, resolvingAgainstBaseURL: true)
-		if nil == comp || "https" != comp!.scheme {
-			throw OAuth2Error.NotUsingTLS
-		}
+        
+        if !clientConfig.httpAllowed {
+            if nil == comp || "https" != comp!.scheme {
+                throw OAuth2Error.NotUsingTLS
+            }
+        }
 		
 		// compose the URL query component
 		comp!.percentEncodedQuery = OAuth2.queryStringFor(params)

--- a/Sources/Base/OAuth2.swift
+++ b/Sources/Base/OAuth2.swift
@@ -317,11 +317,11 @@ public class OAuth2: OAuth2Base {
 		let base = asTokenURL ? (clientConfig.tokenURL ?? clientConfig.authorizeURL) : clientConfig.authorizeURL
 		let comp = NSURLComponents(URL: base, resolvingAgainstBaseURL: true)
         
-        if !clientConfig.httpAllowed {
-            if nil == comp || "https" != comp!.scheme {
-                throw OAuth2Error.NotUsingTLS
-            }
-        }
+		if !clientConfig.httpAllowed {
+			if nil == comp || "https" != comp!.scheme {
+				throw OAuth2Error.NotUsingTLS
+			}
+		}
 		
 		// compose the URL query component
 		comp!.percentEncodedQuery = OAuth2.queryStringFor(params)

--- a/Sources/Base/OAuth2ClientConfig.swift
+++ b/Sources/Base/OAuth2ClientConfig.swift
@@ -56,6 +56,9 @@ public class OAuth2ClientConfig {
 	/// The URL to register a client against.
 	public final var registrationURL: NSURL?
 	
+    /// Whether http is allowed for testing purposes
+    public var httpAllowed = false
+    
 	/// How the client communicates the client secret with the server. Defaults to ".None" if there is no secret, ".ClientSecretPost" if
 	/// "secret_in_body" is `true` and ".ClientSecretBasic" otherwise. Interacts with the `authConfig.secretInBody` client setting.
 	public final var endpointAuthMethod = OAuth2EndpointAuthMethod.None
@@ -104,6 +107,11 @@ public class OAuth2ClientConfig {
 		if let assume = settings["token_assume_unexpired"] as? Bool {
 			accessTokenAssumeUnexpired = assume
 		}
+        
+        if let isHttpAllowed = settings["http_allowed"] as? Bool {
+            httpAllowed = isHttpAllowed
+        }
+        
 	}
 	
 	

--- a/Sources/Base/OAuth2ClientConfig.swift
+++ b/Sources/Base/OAuth2ClientConfig.swift
@@ -59,6 +59,9 @@ public class OAuth2ClientConfig {
     /// Whether http is allowed for testing purposes
     public var httpAllowed = false
     
+    /// Needed for stubbing in unit tests
+    public var addHttpInfoToBodyForTesting = false
+    
 	/// How the client communicates the client secret with the server. Defaults to ".None" if there is no secret, ".ClientSecretPost" if
 	/// "secret_in_body" is `true` and ".ClientSecretBasic" otherwise. Interacts with the `authConfig.secretInBody` client setting.
 	public final var endpointAuthMethod = OAuth2EndpointAuthMethod.None
@@ -112,6 +115,9 @@ public class OAuth2ClientConfig {
             httpAllowed = isHttpAllowed
         }
         
+        if let addStubInfo = settings["enable_stubbing"] as? Bool {
+            addHttpInfoToBodyForTesting = addStubInfo
+        }
 	}
 	
 	

--- a/Sources/Base/OAuth2ClientConfig.swift
+++ b/Sources/Base/OAuth2ClientConfig.swift
@@ -57,10 +57,10 @@ public class OAuth2ClientConfig {
 	public final var registrationURL: NSURL?
 	
     /// Whether http is allowed for testing purposes
-    public var httpAllowed = false
+	public var httpAllowed = false
     
     /// Needed for stubbing in unit tests using OHHTTPStubs library
-    public var addHttpBodyForStubbing = false
+	public var addHttpBodyForStubbing = false
     
 	/// How the client communicates the client secret with the server. Defaults to ".None" if there is no secret, ".ClientSecretPost" if
 	/// "secret_in_body" is `true` and ".ClientSecretBasic" otherwise. Interacts with the `authConfig.secretInBody` client setting.
@@ -111,13 +111,13 @@ public class OAuth2ClientConfig {
 			accessTokenAssumeUnexpired = assume
 		}
         
-        if let isHttpAllowed = settings["http_allowed"] as? Bool {
-            httpAllowed = isHttpAllowed
-        }
+		if let isHttpAllowed = settings["http_allowed"] as? Bool {
+			httpAllowed = isHttpAllowed
+		}
         
-        if let addBody = settings["enable_stubbing"] as? Bool {
-            addHttpBodyForStubbing = addBody
-        }
+		if let addBody = settings["enable_stubbing"] as? Bool {
+			addHttpBodyForStubbing = addBody
+		}
 	}
 	
 	

--- a/Sources/Base/OAuth2ClientConfig.swift
+++ b/Sources/Base/OAuth2ClientConfig.swift
@@ -59,8 +59,8 @@ public class OAuth2ClientConfig {
     /// Whether http is allowed for testing purposes
     public var httpAllowed = false
     
-    /// Needed for stubbing in unit tests
-    public var addHttpInfoToBodyForTesting = false
+    /// Needed for stubbing in unit tests using OHHTTPStubs library
+    public var addHttpBodyForStubbing = false
     
 	/// How the client communicates the client secret with the server. Defaults to ".None" if there is no secret, ".ClientSecretPost" if
 	/// "secret_in_body" is `true` and ".ClientSecretBasic" otherwise. Interacts with the `authConfig.secretInBody` client setting.
@@ -115,8 +115,8 @@ public class OAuth2ClientConfig {
             httpAllowed = isHttpAllowed
         }
         
-        if let addStubInfo = settings["enable_stubbing"] as? Bool {
-            addHttpInfoToBodyForTesting = addStubInfo
+        if let addBody = settings["enable_stubbing"] as? Bool {
+            addHttpBodyForStubbing = addBody
         }
 	}
 	

--- a/Sources/Base/OAuth2ClientConfig.swift
+++ b/Sources/Base/OAuth2ClientConfig.swift
@@ -56,10 +56,10 @@ public class OAuth2ClientConfig {
 	/// The URL to register a client against.
 	public final var registrationURL: NSURL?
 	
-    /// Whether http is allowed for testing purposes
+	/// Whether http is allowed for testing purposes
 	public var httpAllowed = false
     
-    /// Needed for stubbing in unit tests using OHHTTPStubs library
+	/// Needed for stubbing in unit tests using OHHTTPStubs library
 	public var addHttpBodyForStubbing = false
     
 	/// How the client communicates the client secret with the server. Defaults to ".None" if there is no secret, ".ClientSecretPost" if

--- a/Sources/Base/OAuth2ClientCredentials.swift
+++ b/Sources/Base/OAuth2ClientCredentials.swift
@@ -111,7 +111,7 @@ public class OAuth2ClientCredentials: OAuth2 {
 		req.HTTPBody = body.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: true)
         
         if let data = req.HTTPBody  {
-            if clientConfig.httpAllowed {
+            if clientConfig.addHttpInfoToBodyForTesting {
                 NSURLProtocol.setProperty(data, forKey:  "HTTPBody", inRequest: req)
             }
         }

--- a/Sources/Base/OAuth2ClientCredentials.swift
+++ b/Sources/Base/OAuth2ClientCredentials.swift
@@ -109,7 +109,13 @@ public class OAuth2ClientCredentials: OAuth2 {
 			}
 		}
 		req.HTTPBody = body.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: true)
-		
+        
+        if let data = req.HTTPBody  {
+            if clientConfig.httpAllowed {
+                NSURLProtocol.setProperty(data, forKey:  "HTTPBody", inRequest: req)
+            }
+        }
+        
 		return req
 	}
 }

--- a/Sources/Base/OAuth2ClientCredentials.swift
+++ b/Sources/Base/OAuth2ClientCredentials.swift
@@ -110,11 +110,11 @@ public class OAuth2ClientCredentials: OAuth2 {
 		}
 		req.HTTPBody = body.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: true)
         
-        if clientConfig.addHttpBodyForStubbing {
-            if let data = req.HTTPBody  {
-                NSURLProtocol.setProperty(data, forKey:  "HTTPBody", inRequest: req)
-            }
-        }
+		if clientConfig.addHttpBodyForStubbing {
+			if let data = req.HTTPBody  {
+				NSURLProtocol.setProperty(data, forKey:  "HTTPBody", inRequest: req)
+			}
+		}
         
 		return req
 	}

--- a/Sources/Base/OAuth2ClientCredentials.swift
+++ b/Sources/Base/OAuth2ClientCredentials.swift
@@ -110,8 +110,8 @@ public class OAuth2ClientCredentials: OAuth2 {
 		}
 		req.HTTPBody = body.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: true)
         
-        if let data = req.HTTPBody  {
-            if clientConfig.addHttpInfoToBodyForTesting {
+        if clientConfig.addHttpBodyForStubbing {
+            if let data = req.HTTPBody  {
                 NSURLProtocol.setProperty(data, forKey:  "HTTPBody", inRequest: req)
             }
         }

--- a/Sources/Base/OAuth2PasswordGrant.swift
+++ b/Sources/Base/OAuth2PasswordGrant.swift
@@ -138,7 +138,7 @@ public class OAuth2PasswordGrant: OAuth2 {
 		req.HTTPBody = body.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: true)
         
         if let data = req.HTTPBody  {
-            if clientConfig.httpAllowed {
+            if clientConfig.addHttpInfoToBodyForTesting {
                 NSURLProtocol.setProperty(data, forKey:  "HTTPBody", inRequest: req)
             }
         }

--- a/Sources/Base/OAuth2PasswordGrant.swift
+++ b/Sources/Base/OAuth2PasswordGrant.swift
@@ -137,8 +137,9 @@ public class OAuth2PasswordGrant: OAuth2 {
 		}
 		req.HTTPBody = body.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: true)
         
-        if let data = req.HTTPBody  {
-            if clientConfig.addHttpInfoToBodyForTesting {
+       
+        if clientConfig.addHttpBodyForStubbing {
+            if let data = req.HTTPBody  {
                 NSURLProtocol.setProperty(data, forKey:  "HTTPBody", inRequest: req)
             }
         }

--- a/Sources/Base/OAuth2PasswordGrant.swift
+++ b/Sources/Base/OAuth2PasswordGrant.swift
@@ -137,12 +137,11 @@ public class OAuth2PasswordGrant: OAuth2 {
 		}
 		req.HTTPBody = body.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: true)
         
-       
-        if clientConfig.addHttpBodyForStubbing {
-            if let data = req.HTTPBody  {
-                NSURLProtocol.setProperty(data, forKey:  "HTTPBody", inRequest: req)
-            }
-        }
+		if clientConfig.addHttpBodyForStubbing {
+			if let data = req.HTTPBody  {
+				NSURLProtocol.setProperty(data, forKey:  "HTTPBody", inRequest: req)
+			}
+		}
         
 		return req
 	}

--- a/Sources/Base/OAuth2PasswordGrant.swift
+++ b/Sources/Base/OAuth2PasswordGrant.swift
@@ -136,7 +136,13 @@ public class OAuth2PasswordGrant: OAuth2 {
 			}
 		}
 		req.HTTPBody = body.dataUsingEncoding(NSUTF8StringEncoding, allowLossyConversion: true)
-		
+        
+        if let data = req.HTTPBody  {
+            if clientConfig.httpAllowed {
+                NSURLProtocol.setProperty(data, forKey:  "HTTPBody", inRequest: req)
+            }
+        }
+        
 		return req
 	}
 }


### PR DESCRIPTION
httpAllowed parameter can now be set via settings dictionary.